### PR TITLE
making posible to handle multiple files extensions with one writer/reader

### DIFF
--- a/imagepy/core/util/fileio.py
+++ b/imagepy/core/util/fileio.py
@@ -30,7 +30,7 @@ def add_recent(path):
         idx = recent.index(path)
         recent.insert(0, recent.pop(idx))
         rlist.insert(0, rlist.pop(idx))
-    else: 
+    else:
         recent.insert(0, path)
         rlist.insert(0, f(path))
     if len(recent)>=5:
@@ -40,11 +40,18 @@ def add_recent(path):
     ConfigManager.set('recent', recent)
     IPy.curapp.reload_plugins()
 
+def make_wildcard(file_pattern):
+    if isinstance(file_pattern, str):
+        return '%s files (*.%s)|*.%s'%(file_pattern.upper(), file_pattern, file_pattern)
+    else:
+        extensions = ";".join(["*." + x for x in file_pattern[1]])
+        return '%s files (*.%s)|*.%s'%(file_pattern[0].upper(), extensions, extensions)
+
 class Reader(Free):
     para = {'path':''}
 
     def show(self):
-        filt = '|'.join(['%s files (*.%s)|*.%s'%(i.upper(),i,i) for i in self.filt])
+        filt = '|'.join([make_wildcard(i) for i in self.filt])
         return IPy.getpath('Open..', filt, 'open', self.para)
 
     #process
@@ -58,7 +65,7 @@ class Reader(Free):
             a, b = os.path.splitext(fn)
             fn, fe = a, b+fe
             read = ReaderManager.get(fe[1:], None)
-        if read is None: 
+        if read is None:
             return IPy.alert('No reader found for %s'%fe[1:])
         view = ViewerManager.get(fe[1:])
 
@@ -72,7 +79,7 @@ class Writer(Simple):
     para={'path':root_dir}
 
     def show(self):
-        filt = '|'.join(['%s files (*.%s)|*.%s'%(i.upper(),i,i) for i in self.filt])
+        filt = '|'.join([make_wildcard(i) for i in self.filt])
         return IPy.getpath('Save..', filt, 'save', self.para)
 
     #process

--- a/imagepy/menus/File/TIF/tif3d_plgs.py
+++ b/imagepy/menus/File/TIF/tif3d_plgs.py
@@ -5,7 +5,7 @@ import os
 
 class Save(fileio.Writer):
 	title = 'TIF 3D Save'
-	filt = ['TIF']
+	filt = [('TIF', ('TIF','TIFF', 'tif', 'tiff'))]
 	note = ['all', 'stack3d']
 
 	#process
@@ -14,13 +14,13 @@ class Save(fileio.Writer):
 
 class Open(fileio.Reader):
 	title = 'TIF 3D Open'
-	filt = ['TIF']
+	filt = [('TIF', ('TIF','TIFF', 'tif', 'tiff'))]
 
 	#process
 	def run(self, para = None):
 		imgs = imread(para['path']).transpose(2,0,1)
 		fp, fn = os.path.split(para['path'])
-		fn, fe = os.path.splitext(fn) 
+		fn, fe = os.path.splitext(fn)
 		IPy.show_img(imgs, fn)
 
 plgs = [Open, Save]

--- a/imagepy/menus/File/TIF/tif_plgs.py
+++ b/imagepy/menus/File/TIF/tif_plgs.py
@@ -7,10 +7,10 @@ WriterManager.add('tif', imsave)
 
 class OpenFile(fileio.Reader):
 	title = 'TIF Open'
-	filt = ['TIF']
+	filt = [('TIF', ('TIF','TIFF', 'tif', 'tiff'))]
 
 class SaveFile(fileio.Writer):
 	title = 'TIF Save'
-	filt = ['TIF']
+	filt = [('TIF', ('TIF','TIFF', 'tif', 'tiff'))]
 
 plgs = [OpenFile, SaveFile]


### PR DESCRIPTION
handle different variants of extensions in one menu position. 
This is my proposition. In my work I meet different variants of tiff extension. On linux, the file chooser hide all files that do not match the pattern. so it can create problems with searching files. Also on linux size of letters has meaning. 

Maybe it should be done with some more complicated structure like NamedTuple
```python 
import typing 
class FileExtensions(typing.NamedTuple):
	extension_name: str
	extesions_variants: tuple 
```